### PR TITLE
Add Support for Voice Announcements Switch

### DIFF
--- a/beocreate-installer
+++ b/beocreate-installer
@@ -65,6 +65,7 @@ base)
 	npm install xml-stream
 	npm install utf8
 	npm install aplay
+	npm install diacritics
 	apt-get --assume-yes install pigpio
 	npm install pigpio
 	

--- a/beocreate_essentials/pi_system_tools.js
+++ b/beocreate_essentials/pi_system_tools.js
@@ -22,7 +22,6 @@ SOFTWARE.*/
 var child_process = require('child_process');
 
 
-
 var pi_system_tools = module.exports = {
 	setHostname: setHostname,
 	ssh: ssh,


### PR DESCRIPTION
- The system announces its IP address via voice when it doesn't yet know if the client can use an mDNS resolver to connect to it. If a connection comes using the hostname, future announcements are disabled. This adds the option to manually disable them.
- Also brings the diacritics removal module to the server. There has seemingly been issues with generating hostnames client-side, so this should make that more reliable. The diacritics module is added to the list of modules installed by beocreate-installer.