### PR TITLE
Actually restore ^c at the end, rather than setting it to ignore.

### DIFF
--- a/beocreate-installer
+++ b/beocreate-installer
@@ -163,7 +163,7 @@ mixer = Master" > /etc/bt_speaker/config.ini
 	raspi-config nonint do_hostname beocreate-4ch-blank
 	
 	# stop catching ^c at this point
-	trap '' INT
+	trap - INT
 	echo "Base installed. The installation is ready for guided setup. Rebooting in 10 seconds (press Control+C to cancel)." >&3
 	sleep 10
 	reboot


### PR DESCRIPTION
During the prompt at the end "(press Control+C to cancel)" you couldn't actually cancel as ^c was configured to do nothing, rather than being restored and allowed to interrupt the script.