### PR TITLE
It should be simple to re-run the script and have it bring the system to a known state.

### DIFF
--- a/beocreate-installer
+++ b/beocreate-installer
@@ -157,7 +157,9 @@ base)
 	git clone https://github.com/c-larsen/bt-speaker.git
 	cd /home/pi/bt-speaker || exit
 	./install.sh root
-	mkdir /etc/bt_speaker/
+	if [ ! -d  /etc/bt_speaker/ ]; then
+		mkdir /etc/bt_speaker/
+	fi
 	echo "[bt_speaker]
 play_command = aplay -f cd -
 connect_command = aplay -q /home/pi/Music/setup-complete.wav
@@ -300,7 +302,9 @@ sessioncontrol =
 		git clone https://github.com/c-larsen/bt-speaker.git
 		cd /home/pi/bt-speaker || exit
 		./install.sh root
-		mkdir /etc/bt_speaker/
+		if [ ! -d  /etc/bt_speaker/ ]; then
+			mkdir /etc/bt_speaker/
+		fi
 		echo "[bt_speaker]
 play_command = aplay -f cd -
 connect_command = aplay -q /home/pi/Music/setup-complete.wav

--- a/beocreate-installer
+++ b/beocreate-installer
@@ -65,7 +65,7 @@ base)
 	wget -q -P /home/pi/ "https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-armv6l.tar.gz"
 	tar -xvf /home/pi/node-v8.9.3-linux-armv6l.tar.gz
 	cd /home/pi/node-v8.9.3-linux-armv6l
-	cp -R * /usr/local/
+	cp --remove-destination -R * /usr/local/
 	cd /home/pi/
 	
 	echo "Installing Apache..." >&3

--- a/beocreate-installer
+++ b/beocreate-installer
@@ -172,6 +172,10 @@ mixer = Master" > /etc/bt_speaker/config.ini
 
 	echo "Renaming system to beocreate-4ch-blank.local..." >&3
 	raspi-config nonint do_hostname beocreate-4ch-blank
+
+	if [ -f /home/pi/beoconfig.json ]; then
+		mv -b -f /home/pi/beoconfig.json /home/pi/beoconfig.json.old
+	fi
 	
 	# stop catching ^c at this point
 	trap '' INT

--- a/beocreate-installer
+++ b/beocreate-installer
@@ -88,6 +88,9 @@ base)
 	
 	echo "Downloading Bang & Olufsen Create git repository..." >&3
 	apt-get -q --assume-yes install build-essential git xmltoman
+	if [ -d /home/pi/create ]; then
+		rm -rf /home/pi/create
+	fi
 	git clone https://github.com/bang-olufsen/create.git
 	
 	echo "Installing BeoCreate Essentials..." >&3
@@ -124,6 +127,9 @@ base)
 	
 	echo "Disabling onboard audio, enabling HiFiBerry DAC driver and SPI interface..." >&3
 	cd /home/pi/ || exit
+	if [ -d /home/pi/beocreate-tools ]; then
+		rm -rf /home/pi/beocreate-tools
+	fi
 	git clone https://github.com/hifiberry/beocreate-tools.git
 	cd /home/pi/beocreate-tools || exit
 	./enable-hifiberry
@@ -145,6 +151,9 @@ base)
 	
 	echo "Installing Bluetooth audio..." >&3
 	cd /home/pi || exit
+	if [ -d /home/pi/bt-speaker ]; then
+		rm -rf /home/pi/bt-speaker
+	fi
 	git clone https://github.com/c-larsen/bt-speaker.git
 	cd /home/pi/bt-speaker || exit
 	./install.sh root
@@ -238,6 +247,9 @@ device_name = ${PRODUCTNAME}" > spotifyd.conf
 
 		echo "Installing the latest shairport-sync..." >&3
 		cd /home/pi/ || exit
+		if [ -d /home/pi/shairport-sync ]; then
+			rm -rf /home/pi/shairport-sync
+		fi
 		git clone https://github.com/mikebrady/shairport-sync.git
 		cd /home/pi/shairport-sync || exit
 		autoreconf -i -f
@@ -282,6 +294,9 @@ sessioncontrol =
 		apt-get -q --assume-yes update
 		apt-get -q --assume-yes upgrade
 		cd /home/pi || exit
+		if [ -d /home/pi/bt-speaker ]; then
+			rm -rf /home/pi/bt-speaker
+		fi
 		git clone https://github.com/c-larsen/bt-speaker.git
 		cd /home/pi/bt-speaker || exit
 		./install.sh root


### PR DESCRIPTION
**Aim:**
- 	It should be simple to re-run the script and have it upgrade an existing system or fix a partial install that failed part-way through.
- 	It should run correctly over a previously installed version 4
- 	It should run correctly over a half-run version 4
- 	It should run correctly over a previously installed version 3 (tested on my own existing install)

**Decisions:**

If a git clone exists, it will be rm-d and cloned again.  I thought about doing a git pull, but if people have made bad local changes it’s best to wipe it and pull from a known good source. I thought about checking for local changes, but the build process leaves local files, so the git clone is always “dirty”. I thought about making it halt, but I want people to just be able to run the script and have it work.

If people have already successfully installed in the past, installing base is going to reset it back to beocreate-4ch-blank, which I think is OK as again it’s a known starting point for someone who’s having problems.  We also move (but not erase) beoconfig.json to allow people to set-up a system using the guided-setup. 

More words than diff here, I expected this to be harder to do!