### PR TITLE
Support for the latest system software

### DIFF
--- a/SetupTool/create2017.css
+++ b/SetupTool/create2017.css
@@ -386,8 +386,8 @@ p, h1, h2 {
 }
 
 .menu-icon {
-	width: 22px;
-	height: 22px;
+	width: 22px !important;
+	height: 22px !important;
 }
 
 .menu-item {
@@ -438,14 +438,9 @@ p, h1, h2 {
 	margin-left: 15px;
 }
 
-.menu-item.large .menu-icon {
-	width: 44px;
-	height: 44px;
-}
-
-.menu-item.large .menu-icon.right {
-	width: 22px;
-	height: 22px;
+.menu-item .menu-icon.large {
+	width: 44px !important;
+	height: 44px !important;
 }
 
 .menu-label {

--- a/SetupTool/create2017.css
+++ b/SetupTool/create2017.css
@@ -34,7 +34,6 @@ body {
 
 a {
 	color: inherit;
-	text-decoration: inherit;
 }
 
 #chrome {
@@ -203,6 +202,11 @@ header .symbol-button.right {
 
 .menu-group.yellow {
 	background-color: #ffe200;
+	color: black;
+}
+
+.menu-group.green {
+	background-color: #d9f7f5;
 	color: black;
 }
 

--- a/SetupTool/images/speakers/beovox-3000.svg
+++ b/SetupTool/images/speakers/beovox-3000.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="44px" height="44px" viewBox="0 0 44 44" enable-background="new 0 0 44 44" xml:space="preserve">
+<polyline fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="28.5,7.5 
+	27.5,6.5 12.5,13.5 16.5,15.5 31.5,8.5 29.5,7.5 "/>
+<polyline fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="14.5,35.5 
+	12.5,35.5 12.5,13.5 "/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="16.5" y1="37.5" x2="14.5" y2="36.5"/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="14.5" y1="14.5" x2="14.5" y2="36.5"/>
+<polyline fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="16.5,15.5 
+	16.5,37.5 31.5,30.5 31.5,8.5 "/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="29.5" y1="7.5" x2="14.5" y2="14.5"/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="27" y1="11" x2="27" y2="32.5"/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="27" y1="10.5" x2="23.071" y2="10.5"/>
+</svg>

--- a/SetupTool/images/speakers/beovox-5000.svg
+++ b/SetupTool/images/speakers/beovox-5000.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="44px" height="44px" viewBox="0 0 44 44" enable-background="new 0 0 44 44" xml:space="preserve">
+<polyline fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="28.5,2.5 
+	27.5,1.5 12.5,8.5 16.5,10.5 31.5,3.5 29.5,2.5 "/>
+<polyline fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="14.5,40.5 
+	12.5,40.5 12.5,8.5 "/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="16.5" y1="42.5" x2="14.5" y2="41.5"/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="14.5" y1="9.5" x2="14.5" y2="41.5"/>
+<polyline fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="16.5,10.5 
+	16.5,42.5 31.5,35.5 31.5,3.5 "/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="29.5" y1="2.5" x2="14.5" y2="9.5"/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="27" y1="6" x2="27" y2="37.5"/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="27" y1="5.5" x2="23.5" y2="5.5"/>
+</svg>

--- a/SetupTool/images/speakers/beovox-s802.svg
+++ b/SetupTool/images/speakers/beovox-s802.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="44px" height="44px" viewBox="0 0 44 44" enable-background="new 0 0 44 44" xml:space="preserve">
+<polygon fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="22.5,1.5 
+	9.5,7.5 19.5,12.5 32.5,6.5 "/>
+<path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M14.5,6.5"/>
+<polyline fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="19.5,12.5 
+	22.5,14.5 21.5,27 "/>
+<path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M22.5,15.5"/>
+<polyline fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="34.5,23 
+	34.5,36.5 21.5,42.5 "/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="33.5" y1="21.5" x2="33.5" y2="23"/>
+<polyline fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="32.5,6.5 
+	35.5,8.5 34.5,21 "/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="19.5" y1="12.5" x2="19.5" y2="41.5"/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="35.5" y1="8.5" x2="22.5" y2="14.5"/>
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="34.5" y1="21" x2="21.5" y2="27"/>
+<polyline fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="21.5,42.5 
+	21.5,29 34.5,23 "/>
+<polyline fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="9.5,7.5 
+	9.5,36.5 19.505,41.502 21.5,42 "/>
+</svg>

--- a/SetupTool/index.html
+++ b/SetupTool/index.html
@@ -57,6 +57,16 @@ SOFTWARE.
 					<img src="images/hero.jpg" class="hero-image">
 				</div>
 				
+				<div class="menu-group colour-area green hidden" id="system-upgrade-notification">
+					<h2>Are You Up to Date?</h2>
+					<p>If your sound system was installed in November 2018 or earlier, consider upgrading its software. The new system software has several bug fixes and works better and safer with custom sound profiles. The setup tool has been optimised for the new version.</p>
+					<p>For more information, visit <a href="http://www.hifiberry.com/beocreate">HiFiBerry website.</a></p>
+					<div class="menu-item icon left" onclick="upgradeNotification('dismiss');">
+						<img src="symbols-thin-black/done.svg" class="menu-icon">
+						<div class="menu-label">Don't Show Again</div>
+					</div>
+				</div>
+				
 				<div class="menu-group hidden" id="later-previous-setup">
 					
 					<div class="menu-item icon left" onclick="transitionToScreen('connect-to');">

--- a/SetupTool/index.html
+++ b/SetupTool/index.html
@@ -57,7 +57,7 @@ SOFTWARE.
 					<img src="images/hero.jpg" class="hero-image">
 				</div>
 				
-				<div class="menu-group colour-area green hidden" id="system-upgrade-notification">
+				<div class="menu-group colour-area green hidden system-upgrade-notification">
 					<h2>Are You Up to Date?</h2>
 					<p>If your sound system was installed in November 2018 or earlier, consider upgrading its software. The new system software has several bug fixes and works better and safer with custom sound profiles. The setup tool has been optimised for the new version.</p>
 					<p>For more information, visit <a href="http://www.hifiberry.com/beocreate">HiFiBerry website.</a></p>
@@ -371,6 +371,17 @@ SOFTWARE.
 				<div class="menu-group">
 					<p>In this menu you can change any of the initial settings and access advanced options.</p>
 				</div>
+				
+				<div class="menu-group colour-area green hidden system-upgrade-notification">
+					<h2>Upgrade Available</h2>
+					<p>A new system software version was released for your sound system in December 2018. The new version has several bug fixes and works better and safer with custom sound profiles. The setup tool has been optimised for the new version.</p>
+					<p>For more information, visit <a href="http://www.hifiberry.com/beocreate">HiFiBerry website.</a></p>
+					<div class="menu-item icon left" onclick="upgradeNotification('dismiss');">
+						<img src="symbols-thin-black/done.svg" class="menu-icon">
+						<div class="menu-label">Don't Show Again</div>
+					</div>
+				</div>
+				
 				<div class="menu-group">
 					<h2>Essentials</h2>
 					<div class="menu-item icon left has-wifi-only" onclick="transitionToScreen('wifi')">

--- a/SetupTool/index.html
+++ b/SetupTool/index.html
@@ -456,7 +456,8 @@ SOFTWARE.
 			<div class="scroll-area">
 				<div class="menu-group colour-area yellow hidden" id="adjustments-disabled-note">
 					<h2>Adjustments Disabled</h2>
-					<p>You have disabled the sound adjustments from Custom Sound Tuning menu for safety. To enable them again, you can reinstall one of the preset sound profiles from Sound Profiles screen.</p>
+					<p class="v4">You have disabled the sound adjustments from Custom Sound Tuning menu for safety. To enable them again, you can reinstall one of the preset sound profiles from Sound Profiles screen.</p>
+					<p class="v4 hidden">Sound adjustments are disabled, because an unknown sound profile was installed. To enable them again, you can reinstall one of the preset sound profiles from Sound Profiles screen.</p>
 				</div>
 				<div class="menu-group can-disable" id="vol-limit">
 				<h2>Master Volume Limit</h2>
@@ -836,7 +837,7 @@ SOFTWARE.
 				<div class="menu-group center" id="about-top-box">
 				<img class="beo" src="images/bangolufsen.svg">
 				<h2>BeoCreate Setup Tool</h2>
-				<p>Release 4, 6/2018</p>
+				<p>Release 5, 11/2018</p>
 				</div>
 				
 				<div class="menu-group">

--- a/SetupTool/index.html
+++ b/SetupTool/index.html
@@ -59,7 +59,7 @@ SOFTWARE.
 				
 				<div class="menu-group colour-area green hidden system-upgrade-notification">
 					<h2>Are You Up to Date?</h2>
-					<p>If your sound system was installed in November 2018 or earlier, consider upgrading its software. The new system software has several bug fixes and works better and safer with custom sound profiles. The setup tool has been optimised for the new version.</p>
+					<p>If your sound system was installed before December 2018, consider upgrading its software. The new system software has several bug fixes and works better and safer with custom sound profiles. The setup tool has been optimised for the new version.</p>
 					<p>For more information, visit <a href="http://www.hifiberry.com/beocreate">HiFiBerry website.</a></p>
 					<div class="menu-item icon left" onclick="upgradeNotification('dismiss');">
 						<img src="symbols-thin-black/done.svg" class="menu-icon">

--- a/SetupTool/index.html
+++ b/SetupTool/index.html
@@ -457,7 +457,7 @@ SOFTWARE.
 				<div class="menu-group colour-area yellow hidden" id="adjustments-disabled-note">
 					<h2>Adjustments Disabled</h2>
 					<p class="v4">You have disabled the sound adjustments from Custom Sound Tuning menu for safety. To enable them again, you can reinstall one of the preset sound profiles from Sound Profiles screen.</p>
-					<p class="v4 hidden">Sound adjustments are disabled, because an unknown sound profile was installed. To enable them again, you can reinstall one of the preset sound profiles from Sound Profiles screen.</p>
+					<p class="v5 hidden">Sound adjustments are disabled, because an unknown sound profile was installed. To enable them again, you can reinstall one of the preset sound profiles from Sound Profiles screen.</p>
 				</div>
 				<div class="menu-group can-disable" id="vol-limit">
 				<h2>Master Volume Limit</h2>

--- a/SetupTool/offline.appcache
+++ b/SetupTool/offline.appcache
@@ -1,7 +1,7 @@
 CACHE MANIFEST
 
 # BeoCreate Setup Tool
-# Release 4, 6/2018, revision 73
+# Release 5, 11/2018, revision 117
 
 # html files
 index.html
@@ -101,6 +101,9 @@ images/speakers/beovox-cx100.svg
 images/speakers/beovox-cx50.svg
 images/speakers/beovox-rl6000.svg
 images/speakers/beovox-s35.svg
+images/speakers/beovox-s802.svg
+images/speakers/beovox-3000.svg
+images/speakers/beovox-5000.svg
 images/speakers/basic-fullrange.svg
 
 NETWORK:

--- a/SetupTool/offline.appcache
+++ b/SetupTool/offline.appcache
@@ -1,7 +1,7 @@
 CACHE MANIFEST
 
 # BeoCreate Setup Tool
-# Release 5, 11/2018, revision 117
+# Release 5, 11/2018, revision 119
 
 # html files
 index.html

--- a/SetupTool/profiles.json
+++ b/SetupTool/profiles.json
@@ -2,29 +2,47 @@
   "basePath": "http://downloads.hifiberry.com/beocreate/profiles",
   "models": [
     {
-		"name": "Beovox CX50",
+		"name": "Beovox CX 50",
 		"description": "Designed by Jacob Jensen, manufactured 1984-2003",
 		"mfg": "Bang & Olufsen",
 		"file": "beovox-cx50"
     },
     {
-    	"name": "Beovox CX100",
+    	"name": "Beovox CX 100",
     	"description": "Designed by Jacob Jensen, manufactured 1984-2003",
 		"mfg": "Bang & Olufsen",
 		"file": "beovox-cx100"
     },
     {
-    	"name": "Beovox RL6000",
+    	"name": "Beovox RL 6000",
     	"description": "Designed by David Lewis, manufactured 1991-1997",
 		"mfg": "Bang & Olufsen",
 		"file": "beovox-rl6000"
     },
+	{
+		"name": "Beovox 3000",
+		"description": "Designed by Gideon Lindinger-Lowy, manufactured 1988-1991",
+		"mfg": "Bang & Olufsen",
+		"file": "beovox-3000"
+	},
+	{
+		"name": "Beovox 5000",
+		"description": "Designed by Gideon Lindinger-Lowy, manufactured 1988-1992",
+		"mfg": "Bang & Olufsen",
+		"file": "beovox-5000"
+	},
     {
-    	"name": "Beovox S35",
+    	"name": "Beovox S 35",
     	"description": "Designed by Jacob Jensen, manufactured 1977-1980",
 		"mfg": "Bang & Olufsen",
 		"file": "beovox-s35"
     },
+	{
+		"name": "Beovox S 80.2",
+		"description": "Designed by Jacob Jensen, manufactured 1981-1986",
+		"mfg": "Bang & Olufsen",
+		"file": "beovox-s802"
+	},
     {
     	"name": "BeoLab S",
     	"hidden": true,

--- a/SetupTool/scripts/create-setup.js
+++ b/SetupTool/scripts/create-setup.js
@@ -117,12 +117,12 @@ function upgradeNotification(operation) {
 					$("#system-upgrade-notification").removeClass("hidden");
 				}
 			} else {
-				$("#system-upgrade-notification").removeClass("hidden");
+				$(".system-upgrade-notification").removeClass("hidden");
 			}
 			break;
 		case "dismiss":
 			localStorage.beoCreateUpgradeNotificationDismissed = upgradeNotificationID;
-			$("#system-upgrade-notification").addClass("hidden");
+			$(".system-upgrade-notification").addClass("hidden");
 			break;
 	}
 }
@@ -588,6 +588,7 @@ function processReceivedData(data) {
 			if (data.content.serverVersion) {
 				$(".system-version").text("Release "+data.content.serverVersion);
 				systemVersion = data.content.serverVersion;
+				if (systemVersion > 4) upgradeNotification("dismiss");
 			} else {
 				systemVersion = 0;
 			}

--- a/SetupTool/scripts/create-setup.js
+++ b/SetupTool/scripts/create-setup.js
@@ -17,12 +17,13 @@ SOFTWARE.*/
 
 // BANG & OLUFSEN
 // BeoCreate 4-Channel Amplifier Setup
-// Release 3
+// Release 5
 
 var os;
 var screenFlow = ["welcome", "setup-start", "setup-wifi", "setup-profile", "setup-name", "setup-finish", "overview", "sound-adjustments", "name", "wifi", "profile", "custom-tuning", "guide", "sources", "ssh", "connect-to", "software-update", "about"]; // Indicates where different screens exist spatially within the application.
 var sourceNames = {"bluetooth": "Bluetooth", "shairport-sync": "Shairport-sync", "spotifyd": "Spotifyd"};
 var systemVersion = 0;
+
 window.addEventListener('load', function() {
 	
 	// Enables fastclick.js so that buttons respond immediately.
@@ -235,7 +236,7 @@ function addOrUpdateProduct(hostname, details, update, connectNow) {
 	console.log("addOrUpdateProduct() called with hostname: "+hostname);
 	existingProduct = null;
 	for (var i = 0; i < savedProducts.length; i++) {
-		if (savedProducts[i].hostname == hostname) {
+		if (savedProducts[i].hostname.toLowerCase() == hostname.toLowerCase()) {
 			existingProduct = i;
 		}
 	}
@@ -561,9 +562,11 @@ function processReceivedData(data) {
 				}
 			}
 			
-			if (data.content.systemVersion) {
-				$(".system-version").text("Release "+data.content.systemVersion);
-				systemVersion = data.content.systemVersion;
+			if (data.content.serverVersion) {
+				$(".system-version").text("Release "+data.content.serverVersion);
+				systemVersion = data.content.serverVersion;
+			} else {
+				systemVersion = 0;
 			}
 			
 			setupSoundAdjustments(data);
@@ -604,6 +607,13 @@ function processReceivedData(data) {
 					doSetup(data.content.status);
 				}
 			}
+			if (data.content.serverVersion) {
+				$(".system-version").text("Release "+data.content.serverVersion);
+				systemVersion = data.content.serverVersion;
+			} else {
+				systemVersion = 0;
+			}
+			
 			if (data.content.allowStep) {
 				allowAdvancingToStep = data.content.allowStep;
 				checkIfAllowsNextStep();
@@ -774,6 +784,9 @@ function processReceivedData(data) {
 					$("#adjustments-disabled-note").removeClass("hidden");
 				}
 			}
+			break;
+		case "soundAdjustments":
+			setupSoundAdjustments(data);
 			break;
 		case "ssh":
 			if (data.content.enabled == 1) {
@@ -1000,7 +1013,7 @@ function listSoundProfiles() {
 			extraClasses = "";
 			if (selectedProfile == soundProfiles.models[i].file) extraClasses = " selected";
 			if (soundProfiles.models[i].hidden) extraClasses+= " hidden";
-			$("."+container).append('<div class="sound-profile-item menu-item sound-profile-item-' + soundProfiles.models[i].file + extraClasses + ' icon large left radio" onclick="selectSoundProfile('+i+');"><div class="one-row"><img class="menu-icon" src="images/speakers/'+soundProfiles.models[i].file+'.svg"><div class="unified-label-value"><div class="menu-label">' + soundProfiles.models[i].name + '</div><div class="menu-value">' + soundProfiles.models[i].description + '</div></div><img src="symbols-thin-black/checkmark.svg" class="menu-icon right checkmark"></div></div>');
+			$("."+container).append('<div class="sound-profile-item menu-item sound-profile-item-' + soundProfiles.models[i].file + extraClasses + ' icon large left radio" onclick="selectSoundProfile('+i+');"><div class="one-row"><img class="menu-icon large" src="images/speakers/'+soundProfiles.models[i].file+'.svg"><div class="unified-label-value"><div class="menu-label">' + soundProfiles.models[i].name + '</div><div class="menu-value">' + soundProfiles.models[i].description + '</div></div><img src="symbols-thin-black/checkmark.svg" class="menu-icon right checkmark"></div></div>');
 	}
 	
 }
@@ -1033,7 +1046,7 @@ function selectSoundProfile(index) {
 
 
 function setupSoundAdjustments(data) {
-	if (data.content.operation && data.content.operation == "checking") {
+	if (data.content.status && data.content.status == "checking") {
 		$("#vol-limit").addClass("disabled");
 		$("#ch-select").addClass("disabled");
 	} else {
@@ -1041,7 +1054,7 @@ function setupSoundAdjustments(data) {
 			$("#adjustments-disabled-note p.v5").removeClass("hidden");
 			$("#adjustments-disabled-note p.v4").addClass("hidden");
 		} else {
-			$("#adjustments-disabled-note p.v5").elseClass("hidden");
+			$("#adjustments-disabled-note p.v5").addClass("hidden");
 			$("#adjustments-disabled-note p.v4").removeClass("hidden");
 		}
 		$("#adjustments-disabled-note").removeClass("hidden");
@@ -1049,7 +1062,7 @@ function setupSoundAdjustments(data) {
 		if (data.content.volumeLimit != null) {
 			setVolumeLimit(data.content.volumeLimit, true);	
 			$("#vol-limit").removeClass("disabled");
-			if (systemVersion > 4) $("#custom-tuning-warning").removeClass("hidden");
+			if (systemVersion < 5) $("#custom-tuning-warning").removeClass("hidden");
 			$("#adjustments-disabled-note").addClass("hidden");
 		} else {
 			$("#vol-limit").addClass("disabled");
@@ -1058,7 +1071,7 @@ function setupSoundAdjustments(data) {
 			$(".channel-select-item").removeClass("selected");
 			$("#channel-select-item-"+data.content.chSelect).addClass("selected");
 			$("#ch-select").removeClass("disabled");
-			if (systemVersion > 4) $("#custom-tuning-warning").removeClass("hidden");
+			if (systemVersion < 5) $("#custom-tuning-warning").removeClass("hidden");
 			$("#adjustments-disabled-note").addClass("hidden");
 		} else {
 			$(".channel-select-item").removeClass("selected");
@@ -1066,7 +1079,7 @@ function setupSoundAdjustments(data) {
 		}
 		if (data.content.crossoverBands == 3) {
 			$(".3-way-hide").addClass("hidden");
-			if (systemVersion > 4) $("#custom-tuning-warning").removeClass("hidden");
+			if (systemVersion < 5) $("#custom-tuning-warning").removeClass("hidden");
 			$("#adjustments-disabled-note").addClass("hidden");
 		} else {
 			$(".3-way-hide").removeClass("hidden");
@@ -1182,6 +1195,7 @@ $('input').bind('input propertychange', function() {
 	
 	if ($(this).attr("class") == "text-input-system-name") {
 		generatedHostname = generateHostname($(this).val());
+		//$(".text-input-system-name").val($(this).val());
 		systemName = $(this).val();
 		$(".system-name-input-hostname").text(generatedHostname+".local");
 		if ($(this).val()) {
@@ -1198,7 +1212,8 @@ $('input').bind('input propertychange', function() {
 });
 	
 function saveSystemName(setupStep) {
-	$(".text-input-system-name").val("");
+	//systemName = $(".text-input-system-name").val();
+	//generatedHostname = generateHostname(systemName);
 	if (!setupStep) {
 		if (currentSetupStep == 3) {
 			if (allowNext) {
@@ -1216,6 +1231,8 @@ function saveSystemName(setupStep) {
 			sendToProduct({header: "setup", content: {operation: "setName", hostname: generatedHostname, name: systemName, doAutomatedSetup: true}});
 		}
 	}
+	$(".text-input-system-name").val("");
+	$(".system-name-input-hostname-string").addClass("hidden");
 }
 
 function setVolumeLimit(limit, show) {
@@ -1325,10 +1342,12 @@ function help(topic) {
 
 function generateHostname(readableName) {
 	if (systemVersion > 4) {
-		n = readableName.replace(" ", ""); // Remove spaces
+		// Attempts to format a static hostname with the same logic as hostnamectl on the system.
+		n = readableName.replace(/ /g, "-"); // Replace spaces with hyphens
+		n = n.replace(/\./g, "-"); // Replace periods with hyphens
 		n = n.replace(/[^\x00-\x7F]/g, ""); // Remove non-ascii characters
 		n = n.replace(/-+$/g, ""); // Remove hyphens from the end of the name.
-	else {
+	} else {
 		n = readableName.toLowerCase(); // Convert to lower case
 		n = removeDiacritics(n); // Remove diacritics
 		n = n.replace(" ", "-"); // Replace spaces with hyphens

--- a/SetupTool/scripts/create-setup.js
+++ b/SetupTool/scripts/create-setup.js
@@ -22,7 +22,7 @@ SOFTWARE.*/
 var os;
 var screenFlow = ["welcome", "setup-start", "setup-wifi", "setup-profile", "setup-name", "setup-finish", "overview", "sound-adjustments", "name", "wifi", "profile", "custom-tuning", "guide", "sources", "ssh", "connect-to", "software-update", "about"]; // Indicates where different screens exist spatially within the application.
 var sourceNames = {"bluetooth": "Bluetooth", "shairport-sync": "Shairport-sync", "spotifyd": "Spotifyd"};
-var systemVersion = 0;
+var systemVersion = 5; // Default to a later version, override if necessary.
 
 window.addEventListener('load', function() {
 	
@@ -46,6 +46,8 @@ window.addEventListener('load', function() {
 	}
 	updateProductList();
 	selectProduct(selectedProductIndex, true);
+	
+	upgradeNotification("show");
 	
 	if (localStorage.beoCreateSoundProfiles) {
 		soundProfiles = JSON.parse(localStorage.beoCreateSoundProfiles);
@@ -102,6 +104,27 @@ function getOS() {
 	}
 
   return [os, osUI];
+}
+
+var upgradeNotificationID = "5-11/2018";
+function upgradeNotification(operation) {
+	switch (operation) {
+		case "show":
+			if (localStorage.beoCreateUpgradeNotificationDismissed) {
+				upgradeNotificationDismissedID = localStorage.beoCreateUpgradeNotificationDismissed;
+				if (upgradeNotificationDismissedID != upgradeNotificationID) {
+					// Only show the prompt if it hasn't been dismissed for this version.
+					$("#system-upgrade-notification").removeClass("hidden");
+				}
+			} else {
+				$("#system-upgrade-notification").removeClass("hidden");
+			}
+			break;
+		case "dismiss":
+			localStorage.beoCreateUpgradeNotificationDismissed = upgradeNotificationID;
+			$("#system-upgrade-notification").addClass("hidden");
+			break;
+	}
 }
 
 var currentScreen = "welcome";


### PR DESCRIPTION
This version of BeoCreate Setup Tool coincides with the changes to the system software. Changes include:

- Changes to how hostnames are normalised. *diacritics.js* has been phased out and replaced with a simplified hostname normalisation. For backwards compatibility, the old method will be used until a system with matching version number is detected. This means that when manually connecting to the latest systems, the automatic conversion from "human-readable" names to static hostnames may be incorrect. The remedy for now is to type the static hostname directly. In the future, hostnames will be phased out entirely as the means for connection, in favour of much simpler and more reliable *zeroconf* discovery.
- Support for HiFiBerry DSPToolkit. From the user's perspective, this means they no longer have to manually manage the state of custom or default sound profiles – the system will detect these and enable the sound adjustments in the UI as appropriate.
- Update notification. This is an inline banner that tells about the new version. It can be manually dismissed, or if the setup tool detects the new version, it is automatically dismissed. In either case, it won't be shown again.
