### PR TITLE
More precise HiFiBerry link

### DIFF
--- a/SetupTool/index.html
+++ b/SetupTool/index.html
@@ -60,7 +60,7 @@ SOFTWARE.
 				<div class="menu-group colour-area green hidden system-upgrade-notification">
 					<h2>Are You Up to Date?</h2>
 					<p>If your sound system was installed before December 2018, consider upgrading its software. The new system software has several bug fixes and works better and safer with custom sound profiles. The setup tool has been optimised for the new version.</p>
-					<p>For more information, visit <a href="http://www.hifiberry.com/beocreate">HiFiBerry website.</a></p>
+					<p>Download the new software on <a href="https://www.hifiberry.com/beocreate/beocreate-downloads/">HiFiBerry website.</a></p>
 					<div class="menu-item icon left" onclick="upgradeNotification('dismiss');">
 						<img src="symbols-thin-black/done.svg" class="menu-icon">
 						<div class="menu-label">Don't Show Again</div>


### PR DESCRIPTION
Points directly to the downloads page instead of the BeoCreate front
page.