### PR TITLE
Bluetooth Discovery On/Off

### DIFF
--- a/Beocreate2/beo-extensions/bluetooth/bluetooth-client.js
+++ b/Beocreate2/beo-extensions/bluetooth/bluetooth-client.js
@@ -1,17 +1,29 @@
 var bluetooth = (function() {
 
 var bluetoothEnabled = false;
+var bluetoothDiscovery = false;
 
 
 $(document).on("bluetooth", function(event, data) {
 	if (data.header == "bluetoothSettings") {
 		
-		if (data.content.bluetoothEnabled) {
+		if (data.content.settings.bluetoothEnabled) {
 			bluetoothEnabled = true;
 			$("#bluetooth-toggle").addClass("on");
 		} else {
 			bluetoothEnabled = false;
 			$("#bluetooth-toggle").removeClass("on");
+		}
+		if (!data.content.settings.bluetoothDiscoverable || !bluetoothEnabled) {
+			bluetoothDiscovery = false;
+			$("#bluetooth-discovery-start")
+				.removeClass("on")
+				.removeClass("disabled");
+		} else {			
+			bluetoothDiscovery = true;
+			$("#bluetooth-discovery-start")
+				.addClass("on")
+				.addClass("disabled");
 		}
 		beo.notify(false, "bluetooth");
 	}
@@ -28,9 +40,16 @@ function toggleEnabled() {
 	beo.send({target: "bluetooth", header: "bluetoothEnabled", content: {enabled: enabled}});
 }
 
+function startBluetoothDiscovery() {
+	if (bluetoothEnabled) {
+		beo.notify({title: "Starting Bluetooth Discovery...", icon: "attention", timeout: false});
+		beo.send({target: "bluetooth", header: "bluetoothDiscovery", content: {enabled: bluetoothEnabled}});
+	}
+}
 
 return {
-	toggleEnabled: toggleEnabled
+	toggleEnabled: toggleEnabled,
+	startBluetoothDiscovery: startBluetoothDiscovery
 };
 
 })();

--- a/Beocreate2/beo-extensions/bluetooth/menu.html
+++ b/Beocreate2/beo-extensions/bluetooth/menu.html
@@ -11,8 +11,12 @@
 				<div class="menu-label">Enabled</div>
 				<div class="menu-toggle"></div>
 			</div>
-			
-			<p>Connect to '<span class="system-name">the product</span>' in the Bluetooth settings on your device to play music.</p>
+			<div class="menu-item toggle" id="bluetooth-discovery-start" onclick="bluetooth.startBluetoothDiscovery();">
+				<div class="menu-label">Start Bluetooth Discovery</div>
+				<div class="menu-toggle"></div>
+			</div>
+			<p>After starting Bluetooth Discover, connect to '<span class="system-name">the product</span>' in the Bluetooth settings on your device to play music.</p>
+			<p>Bluetooth Discovery mode automatically turns off after 2 minutes.</p>
 			<p>Note: volume control is currently not synchronised between your device and this product.</p>
 		</div>
 	</div>


### PR DESCRIPTION
Adds an option to the Bluetooth Source to start Bluetooth Discover (done by calling `bluetoothctl discovery yes`). For this to work, you also have to modify `/etc/bluetooth/main.cfg` > `DiscoverableTimeout` to be a value larger than 0. I set it to 120 seconds for testing.

Code developed as an offshoot of a discussion on adding security to Bluetooth pairing.
https://support.hifiberry.com/hc/en-us/community/posts/360009540657-HiFiBerry-OS-Bluetooth-Pin-Code-