### PR TITLE
Remove resampling info, change interface file back to previous version

### DIFF
--- a/Beocreate2/beo-extensions/hifiberry-debug/menu.html
+++ b/Beocreate2/beo-extensions/hifiberry-debug/menu.html
@@ -14,22 +14,6 @@
 				<div class="button pill black" onclick="hifiberry_debug.download();" id="diagnostic-download-button">Download Archive</div>
 				<p class="privacy margin-top">No personal information is included in the archive.</p>
 			</div>
-			<hr>
-			<h2 class="disclosure" data-disclosure="#debug-sound-technical">Resampling &amp; Mixing</h2>
-			<div id="debug-sound-technical" class="hidden">
-				<div class="menu-item static">
-					<div class="menu-label">Direct to hardware</div>
-					<div class="menu-value" id="exclusive-audio-status">Yes</div>
-				</div>
-				<p id="exclusive-audio-on-explanation">Sources can output directly to the sound device one at a time, without going through software resampling and mixing.</p>
-				<p id="exclusive-audio-off-explanation">Sound from different sources is resampled and mixed together in software before being sent to the sound device.</p>
-				
-				<div class="menu-item static" id="software-resampling-menu-item">
-					<div class="menu-label">Software resampling</div>
-					<div class="menu-value" id="resampling-rate">192 kHz</div>
-				</div>
-				<p>This may be different from the sampling rate of the sound device.</p>
-			</div>
 		</div>
 	</div>
 

--- a/beocreate_essentials/networking.js
+++ b/beocreate_essentials/networking.js
@@ -596,7 +596,7 @@ dhcpConfig = {wifi: {}, ethernet: {}};
 function readDHCPSettings(forInterface) {
 	path = null;
 	if (forInterface == "wifi") path = "/etc/systemd/network/wireless.network";
-	if (forInterface == "ethernet") path = "/etc/systemd/network/dhcp.network";
+	if (forInterface == "ethernet") path = "/etc/systemd/network/eth0.network";
 	if (path) {
 		if (fs.existsSync(path)) {
 			modified = fs.statSync(path).mtimeMs;
@@ -644,7 +644,7 @@ function readDHCPSettings(forInterface) {
 function writeDHCPSettings(forInterface) {
 	path = null;
 	if (forInterface == "wifi") path = "/etc/systemd/network/wireless.network";
-	if (forInterface == "ethernet") path = "/etc/systemd/network/dhcp.network";
+	if (forInterface == "ethernet") path = "/etc/systemd/network/eth0.network";
 	if (path) {
 		// Saves current configuration back into the file.
 		if (fs.existsSync(path)) {

--- a/beocreate_essentials/networking.js
+++ b/beocreate_essentials/networking.js
@@ -596,7 +596,7 @@ dhcpConfig = {wifi: {}, ethernet: {}};
 function readDHCPSettings(forInterface) {
 	path = null;
 	if (forInterface == "wifi") path = "/etc/systemd/network/wireless.network";
-	if (forInterface == "ethernet") path = "/etc/systemd/network/eth0.network";
+	if (forInterface == "ethernet") path = "/etc/systemd/network/dhcp.network";
 	if (path) {
 		if (fs.existsSync(path)) {
 			modified = fs.statSync(path).mtimeMs;
@@ -644,7 +644,7 @@ function readDHCPSettings(forInterface) {
 function writeDHCPSettings(forInterface) {
 	path = null;
 	if (forInterface == "wifi") path = "/etc/systemd/network/wireless.network";
-	if (forInterface == "ethernet") path = "/etc/systemd/network/eth0.network";
+	if (forInterface == "ethernet") path = "/etc/systemd/network/dhcp.network";
 	if (path) {
 		// Saves current configuration back into the file.
 		if (fs.existsSync(path)) {


### PR DESCRIPTION
HiFiBerryOS is only using exclusive audio mode now, other code has been removed. Therefore, there is no need for the display of sample rate and exclusive audio mode anymore

Also the base buildroot has been reverted to 2019-08 requiring the old naming of the Ethernet configuration file