### PR TITLE
Wildcard redirects for captive portal wifi setup

### DIFF
--- a/Beocreate2/beo-system/beo-server.js
+++ b/Beocreate2/beo-system/beo-server.js
@@ -430,7 +430,10 @@ expressServer.get("/:extension/download/:urlPath", function (req, res) {
 	}
 });
 
-
+// For captive portal wifi setup, redirect all other requests to the hardcoded local wlan0 IP. 
+expressServer.get("*", function(req,res){
+        res.redirect("http://10.0.0.1/");
+});
 
 function addDownloadRoute(extension, urlPath, filePath, permanent = false) {
 	if (extension && urlPath && filePath) {


### PR DESCRIPTION
Fixes #135 

May still require additional setup workflow changes, but at least this enables the wifi config from within captive portal. 