### PR TITLE
Fix poweroff trigger action

### DIFF
--- a/Beocreate2/beo-extensions/general-settings/general-settings-client.js
+++ b/Beocreate2/beo-extensions/general-settings/general-settings-client.js
@@ -53,7 +53,7 @@ function interactSetup(stage, data) {
 			break;
 		case "save":
 			beo.ask();
-			window.interact.saveAction("product-information", "power", {option: interactPowerOption});
+			window.interact.saveAction("general-settings", "power", {option: interactPowerOption});
 			break;
 		case "preview":
 			if (data.option == "shutdown") return "Shut down Raspberry Pi";


### PR DESCRIPTION
It is currently impossible to persist a selected power trigger action (poweroff, reboot). This is caused by an unexpected extension name being passed around.
Fixed by setting the extension name to the correct one.

Fixes [#265](https://github.com/hifiberry/hifiberry-os/issues/265#issue-892636904)

One important thing to note: I am not sure about lines 26 and 31. I don't think that these "product-information" values are incorrect there, but it would be useful if someone could double check them.